### PR TITLE
Issue six problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Clarified installation docs to use `query-to-command` (including `pipx`) and documented recovery steps for accidentally installing the unrelated `qtc` package that can fail with `psycopg2` / `pg_config` errors.
+
 ## [0.4.0] - 2025-11-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,14 +24,45 @@ A command-line utility that converts natural language requests into shell comman
 
 ### Install from PyPI (Recommended)
 
+For isolated CLI installs (recommended), use `pipx`:
+
+```bash
+pipx install query-to-command
+```
+
+If you prefer `pip`:
+
 ```bash
 pip install query-to-command
 ```
+
+> [!IMPORTANT]
+> Install `query-to-command` (the package name), not `qtc`.
+> The `qtc` package on PyPI is a different project and may fail with errors like
+> `psycopg2` / `pg_config executable not found`.
 
 After installation, you can use the `qtc` command directly:
 
 ```bash
 qtc "list all python files in current directory"
+```
+
+### Troubleshooting Installation
+
+If you see installation errors mentioning `qtc-0.0.9`, `psycopg2`, or
+`pg_config executable not found`, you likely installed the wrong package.
+Remove it, then install `query-to-command`:
+
+```bash
+pipx uninstall qtc
+pipx install query-to-command
+```
+
+Or with `pip`:
+
+```bash
+pip uninstall qtc
+pip install query-to-command
 ```
 
 ### Install from Source


### PR DESCRIPTION
## Description

This PR addresses issue #6 by clarifying the installation instructions, particularly for `pipx`, to prevent users from accidentally installing a different PyPI package (`qtc`) instead of `query-to-command`. It also provides troubleshooting steps for the common `psycopg2/pg_config` error encountered when the wrong package is installed.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/update

## Related Issues

Closes #6

## Changes Made

-   Updated `README.md` to explicitly state `pipx install query-to-command` as the correct installation command.
-   Added a warning in `README.md` about the `qtc` PyPI package conflict and provided troubleshooting steps for `psycopg2/pg_config` errors.
-   Added an entry to `CHANGELOG.md` documenting this installation clarification.

## Testing

-   [x] Tests pass locally (verified `poetry run pytest`).
-   [ ] Added tests for new functionality
-   [ ] Updated tests for changed functionality
-   [x] Tested manually (verified `qtc --help` and the updated `README` content).

## Checklist

-   [x] My code follows the project's style guidelines
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas (N/A for docs)
-   [x] I have updated the documentation accordingly
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally
-   [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

This is a documentation-only fix aimed at improving the user experience during installation and preventing common pitfalls related to package naming.

---
<p><a href="https://cursor.com/agents/bc-803f05a8-e879-4df7-82a8-327e5a0c44c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-803f05a8-e879-4df7-82a8-327e5a0c44c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (README/CHANGELOG) with no runtime or release artifact impact.
> 
> **Overview**
> Updates installation documentation to **prefer `pipx install query-to-command`** and explicitly warn users not to install the unrelated `qtc` PyPI package.
> 
> Adds a troubleshooting section with uninstall/reinstall steps for common `psycopg2` / `pg_config` errors caused by installing `qtc`, and records the change under `CHANGELOG.md` *Unreleased* fixes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c669ddeb59c2f2e5c3880b5381eeeb12f7686262. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->